### PR TITLE
Removing unusable panels for older versions

### DIFF
--- a/includes/panels/farm_informations/display_data.php
+++ b/includes/panels/farm_informations/display_data.php
@@ -6,9 +6,11 @@
  * @return string Le code HTML du bouton des informations de la ferme.
  */
 function display_farm_informations_button(): string {
-    $version_class = get_version_class("1.6.0");
+	if (is_game_version_older_than_1_6()) {
+		return "";
+	}
 
-	return "<img src='" . get_images_folder() . "/icons/farm_computer.png' class='$version_class-icon farm-informations-icon view-farm-informations view-farm-informations-" . get_current_player_id() . " button-elements modal-opener icon' alt='Farm informations icon'/>";
+	return "<img src='" . get_images_folder() . "/icons/farm_computer.png' class='farm-informations-icon view-farm-informations view-farm-informations-" . get_current_player_id() . " button-elements modal-opener icon' alt='Farm informations icon'/>";
 }
 
 /**
@@ -17,6 +19,10 @@ function display_farm_informations_button(): string {
  * @return string Le code HTML du panneau des outils du joueur.
  */
 function display_farm_informations(): string {
+	if (is_game_version_older_than_1_6()) {
+		return "";
+	}
+
 	$farm_informations = get_farm_informations_data();
 	$player_id = get_current_player_id();
     $images_path = get_images_folder();

--- a/includes/panels/visited_locations/display_data.php
+++ b/includes/panels/visited_locations/display_data.php
@@ -6,9 +6,11 @@
  * @return string Le code HTML du bouton pour afficher le panneau des lieux visités.
  */
 function display_visited_locations_button(): string {
-    $version_class = get_version_class("1.6.0");
+	if(is_game_version_older_than_1_6()) {
+		return "";
+	}
 
-	return "<img src='" . get_images_folder() . "/icons/location_icon.png' class='$version_class-icon visited-locations-icon view-visited-locations view-visited-locations-" . get_current_player_id() . " button-elements modal-opener icon' alt='Visited locations icon'/>";
+	return "<img src='" . get_images_folder() . "/icons/location_icon.png' class='visited-locations-icon view-visited-locations view-visited-locations-" . get_current_player_id() . " button-elements modal-opener icon' alt='Visited locations icon'/>";
 }
 
 /**
@@ -17,6 +19,10 @@ function display_visited_locations_button(): string {
  * @return string Le code HTML du panneau des lieux visités.
  */
 function display_visited_locations_panel(): string {
+	if(is_game_version_older_than_1_6()) {
+		return "";
+	}
+    
     $player_id = get_current_player_id();
     $visited_locations = get_locations_visited_data();
     $images_path = get_images_folder();

--- a/includes/panels/visited_locations/display_data.php
+++ b/includes/panels/visited_locations/display_data.php
@@ -6,7 +6,7 @@
  * @return string Le code HTML du bouton pour afficher le panneau des lieux visités.
  */
 function display_visited_locations_button(): string {
-	if(is_game_version_older_than_1_6()) {
+	if (is_game_version_older_than_1_6()) {
 		return "";
 	}
 
@@ -19,7 +19,7 @@ function display_visited_locations_button(): string {
  * @return string Le code HTML du panneau des lieux visités.
  */
 function display_visited_locations_panel(): string {
-	if(is_game_version_older_than_1_6()) {
+	if (is_game_version_older_than_1_6()) {
 		return "";
 	}
     


### PR DESCRIPTION
## Description
Removing unusable panels for older versions

## Type of change (✅)
- 🐛 Bug fix ✅
- ✨ New feature
- 📚 Documentation update
- 🔨 Refactoring
- 🧩 Other (please specify): 

## Related Issues
- Linked Issue: Closes #138, Closes #139